### PR TITLE
Pin LMDB to version 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "h5py==3.11.0",
     "unidecode==1.3.2",
     "pydot==1.4.0",
-    "lmdb",
+    "lmdb==2.1.1",
     "truecase",
     "requests>=2.20",
     "pandas==2.2.3",

--- a/requirements.macos.txt
+++ b/requirements.macos.txt
@@ -7,7 +7,7 @@ tf_keras==2.17.0
 h5py==3.11.0
 unidecode==1.3.2
 pydot==1.4.0
-lmdb
+lmdb==2.1.1
 truecase
 requests>=2.20
 pandas==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tf_keras==2.17.0
 h5py==3.11.0
 unidecode==1.3.2
 pydot==1.4.0
-lmdb
+lmdb==2.1.1
 truecase
 requests>=2.20
 pandas==2.2.3


### PR DESCRIPTION
Let's pin lmdb to version 2.1.1 to avoid surprises in the future. Version 2 includes a lot of security and performance fixes that are worth the effort. 