### PR TITLE
Fix problems in multi gpu training

### DIFF
--- a/delft/sequenceLabelling/data_generator.py
+++ b/delft/sequenceLabelling/data_generator.py
@@ -32,6 +32,7 @@ class BaseGenerator(keras.utils.Sequence):
         features=None,
         output_input_offsets: bool = False,
         use_chain_crf: bool = False,
+        drop_last: bool = False,
     ):
         # self.x and self.y are shuffled view of self.original_x and self.original_y
         self.original_x = self.x = x
@@ -50,6 +51,7 @@ class BaseGenerator(keras.utils.Sequence):
         self.max_sequence_length = max_sequence_length
         self.output_input_offsets = output_input_offsets
         self.use_chain_crf = use_chain_crf
+        self.drop_last = drop_last
 
     def __len__(self):
         """
@@ -58,10 +60,20 @@ class BaseGenerator(keras.utils.Sequence):
         # The number of batches is set so that each training sample is seen at most once per epoch
         if self.original_x is None:
             return 0
-        elif (len(self.original_x) % self.batch_size) == 0:
-            return int(np.floor(len(self.original_x) / self.batch_size))
+        n = len(self.original_x)
+        if self.drop_last:
+            remainder = n % self.batch_size
+            if remainder > 0:
+                print(
+                    "Dropping last incomplete batch ({} of {} samples) to ensure uniform batch sizes".format(
+                        remainder, n
+                    )
+                )
+            return n // self.batch_size
+        elif (n % self.batch_size) == 0:
+            return n // self.batch_size
         else:
-            return int(np.floor(len(self.original_x) / self.batch_size) + 1)
+            return n // self.batch_size + 1
 
     @property
     def __getitem__(self, index):
@@ -113,6 +125,7 @@ class DataGenerator(BaseGenerator):
         features=None,
         output_input_offsets=False,
         use_chain_crf=False,
+        drop_last=False,
     ):
 
         super().__init__(
@@ -129,6 +142,7 @@ class DataGenerator(BaseGenerator):
             features=features,
             output_input_offsets=output_input_offsets,
             use_chain_crf=use_chain_crf,
+            drop_last=drop_last,
         )
         if self.embeddings is not None:
             self.embeddings.reopen_lmdb()
@@ -242,6 +256,7 @@ class DataGeneratorTransformers(BaseGenerator):
         features=None,
         output_input_offsets=False,
         use_chain_crf=False,
+        drop_last=False,
     ):
 
         super().__init__(
@@ -258,6 +273,7 @@ class DataGeneratorTransformers(BaseGenerator):
             features=features,
             output_input_offsets=output_input_offsets,
             use_chain_crf=use_chain_crf,
+            drop_last=drop_last,
         )
 
         if self.bert_preprocessor.empty_features_vector is None:

--- a/delft/sequenceLabelling/tagger.py
+++ b/delft/sequenceLabelling/tagger.py
@@ -2,7 +2,6 @@ import datetime
 
 import numpy as np
 import tensorflow as tf
-from packaging import version
 
 from delft.sequenceLabelling.data_generator import DataGeneratorTransformers
 from delft.sequenceLabelling.preprocess import Preprocessor
@@ -24,13 +23,6 @@ class Tagger(object):
         if multi_gpu:
             strategy = tf.distribute.MirroredStrategy()
             print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
-
-            # This trick avoid an exception being through when the --multi-gpu approach is used on a single GPU system.
-            # It might be removed with TF 2.10 https://github.com/tensorflow/tensorflow/issues/50487
-            if version.parse(tf.__version__) < version.parse("2.10.0"):
-                import atexit
-
-                atexit.register(strategy._extended._collective_ops._pool.close)  # type: ignore
 
             with strategy.scope():
                 return self.tag_(texts, output_format, features)

--- a/delft/sequenceLabelling/trainer.py
+++ b/delft/sequenceLabelling/trainer.py
@@ -41,6 +41,7 @@ class Trainer(object):
         transformer_preprocessor=None,
         enable_wandb=False,
         nb_workers=6,
+        multi_gpu: bool = False,
     ):
 
         # for single model training
@@ -59,6 +60,7 @@ class Trainer(object):
         self.preprocessor = preprocessor
         self.transformer_preprocessor = transformer_preprocessor
         self.enable_wandb = enable_wandb
+        self.multi_gpu = multi_gpu
 
     def train(
         self,
@@ -189,7 +191,7 @@ class Trainer(object):
                 shuffle=True,
                 features=f_train,
                 use_chain_crf=self.model_config.use_chain_crf,
-                drop_last=True,
+                drop_last=self.multi_gpu,
             )
 
             validation_generator = generator(
@@ -205,7 +207,7 @@ class Trainer(object):
                 features=f_valid,
                 output_input_offsets=True,
                 use_chain_crf=self.model_config.use_chain_crf,
-                drop_last=True,
+                drop_last=self.multi_gpu,
             )
 
             _callbacks = get_callbacks(
@@ -237,7 +239,7 @@ class Trainer(object):
                 shuffle=True,
                 features=feature_all,
                 use_chain_crf=self.model_config.use_chain_crf,
-                drop_last=True,
+                drop_last=self.multi_gpu,
             )
 
             _callbacks = get_callbacks(

--- a/delft/sequenceLabelling/trainer.py
+++ b/delft/sequenceLabelling/trainer.py
@@ -189,6 +189,7 @@ class Trainer(object):
                 shuffle=True,
                 features=f_train,
                 use_chain_crf=self.model_config.use_chain_crf,
+                drop_last=True,
             )
 
             validation_generator = generator(
@@ -204,6 +205,7 @@ class Trainer(object):
                 features=f_valid,
                 output_input_offsets=True,
                 use_chain_crf=self.model_config.use_chain_crf,
+                drop_last=True,
             )
 
             _callbacks = get_callbacks(
@@ -235,6 +237,7 @@ class Trainer(object):
                 shuffle=True,
                 features=feature_all,
                 use_chain_crf=self.model_config.use_chain_crf,
+                drop_last=True,
             )
 
             _callbacks = get_callbacks(

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -1,7 +1,5 @@
 import os
 
-from packaging import version
-
 # for using legacy Keras 2, and not Keras 3 installed by default from TensorFlow 2.16
 os.environ["TF_USE_LEGACY_KERAS"] = "1"
 os.environ["KERAS_BACKEND"] = "tensorflow"
@@ -242,12 +240,6 @@ class Sequence(object):
             strategy = tf.distribute.MirroredStrategy()
             print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
 
-            # This trick avoid an exception being through when the --multi-gpu approach is used on a single GPU system.
-            # It might be removed with TF 2.10 https://github.com/tensorflow/tensorflow/issues/50487
-            import atexit
-
-            atexit.register(strategy._extended._collective_ops._pool.close)  # type: ignore
-
             with strategy.scope():
                 self.train_(x_train, y_train, f_train, x_valid, y_valid, f_valid, incremental, callbacks)
         else:
@@ -336,12 +328,6 @@ class Sequence(object):
         if multi_gpu:
             strategy = tf.distribute.MirroredStrategy()
             print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
-
-            # This trick avoid an exception being through when the --multi-gpu approach is used on a single GPU system.
-            # It might be removed with TF 2.10 https://github.com/tensorflow/tensorflow/issues/50487
-            import atexit
-
-            atexit.register(strategy._extended._collective_ops._pool.close)  # type: ignore
 
             with strategy.scope():
                 self.train_nfold_(x_train, y_train, x_valid, y_valid, f_train, f_valid, incremental, callbacks)
@@ -627,13 +613,6 @@ class Sequence(object):
         if multi_gpu:
             strategy = tf.distribute.MirroredStrategy()
             print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
-
-            # This trick avoid an exception being through when the --multi-gpu approach is used on a single GPU system.
-            # It might be removed with TF 2.10 https://github.com/tensorflow/tensorflow/issues/50487
-            if version.parse(tf.__version__) < version.parse("2.10.0"):
-                import atexit
-
-                atexit.register(strategy._extended._collective_ops._pool.close)  # type: ignore
 
             with strategy.scope():
                 return self.tag_(texts, output_format, features, batch_size)

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -238,10 +238,24 @@ class Sequence(object):
         # TBD if valid is None, segment train to get one if early_stop is True
         if multi_gpu:
             strategy = tf.distribute.MirroredStrategy()
-            print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
+            num_replicas = strategy.num_replicas_in_sync
+            print("Running with multi-gpu. Number of devices: {}".format(num_replicas))
 
-            with strategy.scope():
-                self.train_(x_train, y_train, f_train, x_valid, y_valid, f_valid, incremental, callbacks)
+            original_batch_size = self.training_config.batch_size
+            if original_batch_size % num_replicas != 0:
+                adjusted = ((original_batch_size // num_replicas) + 1) * num_replicas
+                print(
+                    "Adjusting training batch_size from {} to {} (must be a multiple of {} GPUs)".format(
+                        original_batch_size, adjusted, num_replicas
+                    )
+                )
+                self.training_config.batch_size = adjusted
+
+            try:
+                with strategy.scope():
+                    self.train_(x_train, y_train, f_train, x_valid, y_valid, f_valid, incremental, callbacks)
+            finally:
+                self.training_config.batch_size = original_batch_size
         else:
             self.train_(x_train, y_train, f_train, x_valid, y_valid, f_valid, incremental, callbacks)
 
@@ -327,10 +341,24 @@ class Sequence(object):
     ):
         if multi_gpu:
             strategy = tf.distribute.MirroredStrategy()
-            print("Running with multi-gpu. Number of devices: {}".format(strategy.num_replicas_in_sync))
+            num_replicas = strategy.num_replicas_in_sync
+            print("Running with multi-gpu. Number of devices: {}".format(num_replicas))
 
-            with strategy.scope():
-                self.train_nfold_(x_train, y_train, x_valid, y_valid, f_train, f_valid, incremental, callbacks)
+            original_batch_size = self.training_config.batch_size
+            if original_batch_size % num_replicas != 0:
+                adjusted = ((original_batch_size // num_replicas) + 1) * num_replicas
+                print(
+                    "Adjusting training batch_size from {} to {} (must be a multiple of {} GPUs)".format(
+                        original_batch_size, adjusted, num_replicas
+                    )
+                )
+                self.training_config.batch_size = adjusted
+
+            try:
+                with strategy.scope():
+                    self.train_nfold_(x_train, y_train, x_valid, y_valid, f_train, f_valid, incremental, callbacks)
+            finally:
+                self.training_config.batch_size = original_batch_size
         else:
             self.train_nfold_(x_train, y_train, x_valid, y_valid, f_train, f_valid, incremental, callbacks)
 

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -253,7 +253,17 @@ class Sequence(object):
 
             try:
                 with strategy.scope():
-                    self.train_(x_train, y_train, f_train, x_valid, y_valid, f_valid, incremental, callbacks)
+                    self.train_(
+                        x_train,
+                        y_train,
+                        f_train,
+                        x_valid,
+                        y_valid,
+                        f_valid,
+                        incremental,
+                        callbacks,
+                        multi_gpu=True,
+                    )
             finally:
                 self.training_config.batch_size = original_batch_size
         else:
@@ -269,6 +279,7 @@ class Sequence(object):
         f_valid=None,
         incremental=False,
         callbacks=None,
+        multi_gpu=False,
     ):
         # TBD if valid is None, segment train to get one if early_stop is True
 
@@ -322,6 +333,7 @@ class Sequence(object):
             transformer_preprocessor=self.model.transformer_preprocessor,
             enable_wandb=self.report_to_wandb,
             nb_workers=self.nb_workers,
+            multi_gpu=multi_gpu,
         )
         trainer.train(
             x_train, y_train, x_valid, y_valid, features_train=f_train, features_valid=f_valid, callbacks=callbacks
@@ -356,7 +368,17 @@ class Sequence(object):
 
             try:
                 with strategy.scope():
-                    self.train_nfold_(x_train, y_train, x_valid, y_valid, f_train, f_valid, incremental, callbacks)
+                    self.train_nfold_(
+                        x_train,
+                        y_train,
+                        x_valid,
+                        y_valid,
+                        f_train,
+                        f_valid,
+                        incremental,
+                        callbacks,
+                        multi_gpu=True,
+                    )
             finally:
                 self.training_config.batch_size = original_batch_size
         else:
@@ -372,6 +394,7 @@ class Sequence(object):
         f_valid=None,
         incremental=False,
         callbacks=None,
+        multi_gpu=False,
     ):
         x_all = np.concatenate((x_train, x_valid), axis=0) if x_valid is not None else x_train
         y_all = np.concatenate((y_train, y_valid), axis=0) if y_valid is not None else y_train
@@ -399,6 +422,7 @@ class Sequence(object):
             checkpoint_path=self.log_dir,
             preprocessor=self.p,
             nb_workers=self.nb_workers,
+            multi_gpu=multi_gpu,
         )
 
         trainer.train_nfold(x_train, y_train, x_valid, y_valid, f_train=f_train, f_valid=f_valid, callbacks=callbacks)


### PR DESCRIPTION
This PR removes an old workaround for TF 2.10 which was crashing TF 2.17 and it fixes the issue with batching on multi-gpu where the batch don't match the number of GPU leading to crashes because certain GPUs get empty sequences. 