### PR TITLE
Fix invalid wokers numbers for classification

### DIFF
--- a/delft/textClassification/models.py
+++ b/delft/textClassification/models.py
@@ -250,8 +250,9 @@ class BaseModel(object):
         multiprocessing = True
 
         if use_main_thread_only:
-            # worker at 0 means the training will be executed in the main thread
-            nb_workers = 0
+            # tf_keras 2.17 requires workers >= 1; workers=1 with
+            # use_multiprocessing=False runs in the main thread.
+            nb_workers = 1
             multiprocessing = False
 
         y = self.model.predict(predict_generator, use_multiprocessing=multiprocessing, workers=nb_workers)


### PR DESCRIPTION
When multiprocessing is disabled, the flag for running the prediction in the main process was not updated. 

Unfortunately this affect also grobid 0.9.0 when licence/copyright models are enabled: 

```
ERROR [2026-04-12 10:40:59,063] org.grobid.core.jni.DeLFTClassifierModel: DeLFT model classification via JEP failed
! jep.JepException: <class 'NameError'>: name 'jsondict' is not defined
! at <string>.<module>(<string>:1)
! at jep.Jep.eval(Native Method)
! at jep.Jep.eval(Jep.java:357)
! at org.grobid.core.jni.DeLFTClassifierModel$ClassificationTask.call(DeLFTClassifierModel.java:136)
! at org.grobid.core.jni.DeLFTClassifierModel$ClassificationTask.call(DeLFTClassifierModel.java:78)
! at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
! at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
! at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
! at java.base/java.lang.Thread.run(Thread.java:1583)
```