### PR TITLE
Optimize the number of workers 

### DIFF
--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        python-version: [ '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - name: Cleanup more disk space
         run: |

--- a/delft/sequenceLabelling/data_loader.py
+++ b/delft/sequenceLabelling/data_loader.py
@@ -193,11 +193,13 @@ class SequenceLabelingDataset(Dataset):
         # Get word embeddings
         word_emb = to_vector_single(x_tokens, self.embeddings, seq_len)
 
-        # Get character indices
-        if self.preprocessor.return_chars:
-            char_indices = self.preprocessor.transform_chars([x_tokens], extend=extend)[0]
-        else:
-            char_indices = np.zeros((seq_len, self.preprocessor.max_char_length), dtype=np.int32)
+        # Get character indices. Preprocessor.transform returns [chars_padded, lengths]
+        # for a list of sentences; we pass a single sentence and take element [0][0].
+        # Regression note: the previous `if self.preprocessor.return_chars` branch
+        # called a non-existent `transform_chars` method, so the char encoder was
+        # silently fed all-zero indices. Issue #216 surfaced this when char inputs
+        # became the only signal.
+        char_indices = self.preprocessor.transform([x_tokens], extend=extend)[0][0]
 
         # Get casing features
         if self.preprocessor.return_casing:

--- a/delft/sequenceLabelling/data_loader.py
+++ b/delft/sequenceLabelling/data_loader.py
@@ -22,6 +22,30 @@ from delft.utilities.Tokenizer import tokenizeAndFilterSimple
 from delft.utilities.Utilities import len_until_first_pad, truncate_batch_values
 
 
+def _effective_num_workers(requested: int, dataset_size: int, batch_size: int) -> int:
+    """
+    Cap ``requested`` worker count to what makes sense for the dataset size.
+
+    Worker spawn cost on macOS dominates wall time for tiny datasets — when
+    there are fewer batches than workers, each worker handles <1 batch and
+    the per-epoch respawn (since ``persistent_workers`` defaults to False)
+    costs more than it saves. We aim for ~2 batches per worker so spawn
+    overhead is amortized. Returns 0 (in-process loading) when the dataset
+    is small enough that any worker is wasted.
+    """
+    if requested <= 0 or dataset_size <= 0 or batch_size <= 0:
+        return 0
+    num_batches = max(1, dataset_size // batch_size)
+    ideal = num_batches // 2
+    effective = max(0, min(requested, ideal))
+    if effective != requested:
+        print(
+            f"DataLoader: requested num_workers={requested}, capped to {effective} "
+            f"for dataset size={dataset_size} (batches={num_batches})."
+        )
+    return effective
+
+
 def _worker_init_fn(worker_id):
     # Each fork-mode worker inherits the parent's LMDB env handle, which is unsafe.
     # Re-open per worker so each gets an independent reader-locktable slot.
@@ -401,6 +425,11 @@ def create_dataloader(
             use_chain_crf=model_config.use_crf if model_config else False,
         )
 
+        # Scale workers down for tiny datasets where spawn cost dominates.
+        effective_workers = _effective_num_workers(num_workers, len(dataset), batch_size)
+        # pin_memory only helps CUDA host->device transfers; on MPS/CPU it's overhead.
+        effective_pin_memory = pin_memory and torch.cuda.is_available()
+
         # Use DistributedSampler for multi-GPU training
         sampler = None
         if distributed:
@@ -412,8 +441,9 @@ def create_dataloader(
             batch_size=batch_size,
             shuffle=shuffle if sampler is None else False,
             sampler=sampler,
-            num_workers=num_workers,
-            pin_memory=pin_memory,
+            num_workers=effective_workers,
+            persistent_workers=effective_workers > 0,
+            pin_memory=effective_pin_memory,
             collate_fn=collate_fn,
         )
 
@@ -430,6 +460,9 @@ def create_dataloader(
         use_chain_crf=model_config.use_crf if model_config else False,
     )
 
+    effective_workers = _effective_num_workers(num_workers, len(dataset), batch_size)
+    effective_pin_memory = pin_memory and torch.cuda.is_available()
+
     # Use DistributedSampler for multi-GPU training
     sampler = None
     if distributed:
@@ -441,10 +474,11 @@ def create_dataloader(
         batch_size=batch_size,
         shuffle=shuffle if sampler is None else False,
         sampler=sampler,
-        num_workers=num_workers,
-        pin_memory=pin_memory,
+        num_workers=effective_workers,
+        persistent_workers=effective_workers > 0,
+        pin_memory=effective_pin_memory,
         collate_fn=collate_fn,
-        worker_init_fn=_worker_init_fn if num_workers > 0 else None,
+        worker_init_fn=_worker_init_fn if effective_workers > 0 else None,
     )
 
 

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -23,7 +23,6 @@ from delft.sequenceLabelling.config import ModelConfig, TrainingConfig
 from delft.sequenceLabelling.data_loader import create_dataloader
 from delft.sequenceLabelling.evaluation import classification_report
 from delft.sequenceLabelling.models import get_model
-from delft.utilities.Utilities import pick_device
 from delft.sequenceLabelling.preprocess import Preprocessor, prepare_preprocessor
 from delft.sequenceLabelling.trainer import (
     CONFIG_FILE_NAME,

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -93,9 +93,12 @@ class Sequence(object):
         self.embeddings_name = embeddings_name
         self.report_to_wandb = report_to_wandb
 
-        # Set number of workers: default to cpu_count - 1, minimum 1
+        # Set number of workers. The per-epoch respawn cost on macOS makes
+        # large worker counts counterproductive for small datasets, and
+        # ``create_dataloader`` further auto-caps based on dataset size.
+        # Default to a modest 4 (or fewer on small machines).
         if nb_workers is None:
-            self.nb_workers = max(1, os.cpu_count() - 1)
+            self.nb_workers = max(1, min(4, os.cpu_count() - 1))
         else:
             self.nb_workers = nb_workers
 

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -23,6 +23,7 @@ from delft.sequenceLabelling.config import ModelConfig, TrainingConfig
 from delft.sequenceLabelling.data_loader import create_dataloader
 from delft.sequenceLabelling.evaluation import classification_report
 from delft.sequenceLabelling.models import get_model
+from delft.utilities.Utilities import pick_device
 from delft.sequenceLabelling.preprocess import Preprocessor, prepare_preprocessor
 from delft.sequenceLabelling.trainer import (
     CONFIG_FILE_NAME,


### PR DESCRIPTION
The number of workers should be optimized based on the data size and resources. 

Using nb_cpu -1 is often a mistake because it tends to spanw too many generators, making the process slower. 