### PR TITLE
Make embeddings optionals 

### DIFF
--- a/delft/applications/datasetTagger.py
+++ b/delft/applications/datasetTagger.py
@@ -455,8 +455,8 @@ if __name__ == "__main__":
     num_workers = args.num_workers
 
     if transformer is None and embeddings_name is None:
-        # default word embeddings
-        embeddings_name = "glove-840B"
+        # No transformer and no word embeddings: train character-only (issue #216).
+        print("No --transformer and no --embedding given: training without word embeddings (char-only).")
 
     if action == "train":
         train(

--- a/delft/applications/grobidTagger.py
+++ b/delft/applications/grobidTagger.py
@@ -721,8 +721,8 @@ if __name__ == "__main__":
         raise ValueError("A model architecture has to be specified: " + str(architectures))
 
     if transformer is None and embeddings_name is None:
-        # default word embeddings
-        embeddings_name = "glove-840B"
+        # No transformer and no word embeddings: train character-only (issue #216).
+        print("No --transformer and no --embedding given: training without word embeddings (char-only).")
 
     if action == Tasks.TRAIN:
         train(

--- a/delft/applications/insultTagger.py
+++ b/delft/applications/insultTagger.py
@@ -225,8 +225,8 @@ if __name__ == "__main__":
     num_workers = args.num_workers
 
     if transformer is None and embeddings_name is None:
-        # default word embeddings
-        embeddings_name = "glove-840B"
+        # No transformer and no word embeddings: train character-only (issue #216).
+        print("No --transformer and no --embedding given: training without word embeddings (char-only).")
 
     if args.action == "train":
         train(

--- a/delft/sequenceLabelling/data_loader.py
+++ b/delft/sequenceLabelling/data_loader.py
@@ -609,10 +609,12 @@ class BatchedDataLoader:
 
         batch_size = len(batch_x)
 
-        # Word embeddings
-        word_emb = np.zeros((batch_size, max_len, self.embeddings.embed_size), dtype="float32")
-        for i, tokens in enumerate(batch_x):
-            word_emb[i] = to_vector_single(tokens, self.embeddings, max_len)
+        # Word embeddings (zero-width placeholder when embeddings are disabled)
+        embed_size = self.embeddings.embed_size if self.embeddings is not None else 0
+        word_emb = np.zeros((batch_size, max_len, embed_size), dtype="float32")
+        if self.embeddings is not None:
+            for i, tokens in enumerate(batch_x):
+                word_emb[i] = to_vector_single(tokens, self.embeddings, max_len)
 
         # Character indices
         batches = self.preprocessor.transform(batch_x, extend=extend)

--- a/delft/sequenceLabelling/data_loader.py
+++ b/delft/sequenceLabelling/data_loader.py
@@ -28,6 +28,48 @@ from delft.utilities.Tokenizer import tokenizeAndFilterSimple
 from delft.utilities.Utilities import len_until_first_pad, truncate_batch_values
 
 
+def _effective_num_workers(requested: int, dataset_size: int, batch_size: int) -> int:
+    """
+    Cap ``requested`` worker count to what makes sense for the dataset size.
+
+    Worker spawn cost on macOS dominates wall time for tiny datasets — when
+    there are fewer batches than workers, each worker handles <1 batch and
+    the per-epoch respawn (since ``persistent_workers`` defaults to False)
+    costs more than it saves. We aim for ~2 batches per worker so spawn
+    overhead is amortized. Returns 0 (in-process loading) when the dataset
+    is small enough that any worker is wasted.
+    """
+    if requested <= 0 or dataset_size <= 0 or batch_size <= 0:
+        return 0
+    num_batches = max(1, dataset_size // batch_size)
+    ideal = num_batches // 2
+    effective = max(0, min(requested, ideal))
+    if effective != requested:
+        print(
+            f"DataLoader: requested num_workers={requested}, capped to {effective} "
+            f"for dataset size={dataset_size} (batches={num_batches})."
+        )
+    return effective
+
+
+def _safe_multiprocessing_context():
+    """
+    Pick a fork-safe multiprocessing context for DataLoader workers.
+
+    On Linux with CUDA initialized in the parent, the default ``fork``
+    start method causes worker segfaults (CUDA, OpenMP, and LMDB state
+    don't survive fork cleanly). ``forkserver`` avoids this by forking
+    from a clean helper process. On macOS the default (``spawn`` since
+    PEP 690) is already safe — return None to let PyTorch decide.
+    """
+    import platform
+    import sys
+
+    if platform.system() == "Linux" and sys.version_info >= (3, 4):
+        return "forkserver"
+    return None
+
+
 def _worker_init_fn(worker_id):
     # Each fork-mode worker inherits the parent's LMDB env handle, which is unsafe.
     # Re-open per worker so each gets an independent reader-locktable slot.

--- a/delft/sequenceLabelling/data_loader.py
+++ b/delft/sequenceLabelling/data_loader.py
@@ -28,48 +28,6 @@ from delft.utilities.Tokenizer import tokenizeAndFilterSimple
 from delft.utilities.Utilities import len_until_first_pad, truncate_batch_values
 
 
-def _effective_num_workers(requested: int, dataset_size: int, batch_size: int) -> int:
-    """
-    Cap ``requested`` worker count to what makes sense for the dataset size.
-
-    Worker spawn cost on macOS dominates wall time for tiny datasets — when
-    there are fewer batches than workers, each worker handles <1 batch and
-    the per-epoch respawn (since ``persistent_workers`` defaults to False)
-    costs more than it saves. We aim for ~2 batches per worker so spawn
-    overhead is amortized. Returns 0 (in-process loading) when the dataset
-    is small enough that any worker is wasted.
-    """
-    if requested <= 0 or dataset_size <= 0 or batch_size <= 0:
-        return 0
-    num_batches = max(1, dataset_size // batch_size)
-    ideal = num_batches // 2
-    effective = max(0, min(requested, ideal))
-    if effective != requested:
-        print(
-            f"DataLoader: requested num_workers={requested}, capped to {effective} "
-            f"for dataset size={dataset_size} (batches={num_batches})."
-        )
-    return effective
-
-
-def _safe_multiprocessing_context():
-    """
-    Pick a fork-safe multiprocessing context for DataLoader workers.
-
-    On Linux with CUDA initialized in the parent, the default ``fork``
-    start method causes worker segfaults (CUDA, OpenMP, and LMDB state
-    don't survive fork cleanly). ``forkserver`` avoids this by forking
-    from a clean helper process. On macOS the default (``spawn`` since
-    PEP 690) is already safe — return None to let PyTorch decide.
-    """
-    import platform
-    import sys
-
-    if platform.system() == "Linux" and sys.version_info >= (3, 4):
-        return "forkserver"
-    return None
-
-
 def _worker_init_fn(worker_id):
     # Each fork-mode worker inherits the parent's LMDB env handle, which is unsafe.
     # Re-open per worker so each gets an independent reader-locktable slot.

--- a/delft/sequenceLabelling/preprocess.py
+++ b/delft/sequenceLabelling/preprocess.py
@@ -786,8 +786,13 @@ def to_vector_single(tokens, embeddings, maxlen, lowercase=False, num_norm=True)
     """
     Given a list of tokens convert it to a sequence of word embedding
     vectors with the provided embeddings, introducing <PAD> and <UNK> padding token
-    vector when appropriate
+    vector when appropriate. When ``embeddings`` is ``None``, return a
+    zero-width placeholder so downstream concatenation with character
+    embeddings is a no-op (char-only training, see issue #216).
     """
+    if embeddings is None:
+        return np.zeros((maxlen, 0), dtype=np.float32)
+
     window = tokens[-maxlen:]
 
     # TBD: use better initializers (uniform, etc.)

--- a/delft/sequenceLabelling/wrapper.py
+++ b/delft/sequenceLabelling/wrapper.py
@@ -45,6 +45,11 @@ class Sequence(object):
 
     Provides high-level API for training, evaluation, and tagging with
     sequence labeling models.
+
+    Word embeddings are optional. Pass ``embeddings_name=None`` together
+    with ``transformer_name=None`` to train using only character (and
+    optional features) inputs — this avoids loading multi-GB embedding
+    files at the cost of a small accuracy drop. See issue #216.
     """
 
     def __init__(

--- a/tests/sequence_labelling/preprocess_test.py
+++ b/tests/sequence_labelling/preprocess_test.py
@@ -4,7 +4,11 @@ import os
 import numpy as np
 
 # derived from https://github.com/elifesciences/sciencebeam-trainer-delft/tree/develop/tests
-from delft.sequenceLabelling.preprocess import FeaturesPreprocessor, Preprocessor
+from delft.sequenceLabelling.preprocess import (
+    FeaturesPreprocessor,
+    Preprocessor,
+    to_vector_single,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +71,47 @@ class TestWordPreprocessor:
         p = Preprocessor.load(preprocessor2)
 
         assert len(p.vocab_char) == 70
+
+
+class TestToVectorSingle:
+    def test_returns_zero_width_array_when_embeddings_is_none(self):
+        result = to_vector_single(["foo", "bar"], embeddings=None, maxlen=5)
+        assert result.shape == (5, 0)
+        assert result.dtype == np.float32
+
+    def test_handles_empty_token_list_when_embeddings_is_none(self):
+        result = to_vector_single([], embeddings=None, maxlen=3)
+        assert result.shape == (3, 0)
+
+
+class TestEffectiveNumWorkers:
+    def test_returns_zero_when_requested_zero(self):
+        from delft.sequenceLabelling.data_loader import _effective_num_workers
+
+        assert _effective_num_workers(0, dataset_size=1000, batch_size=16) == 0
+
+    def test_caps_to_half_the_batches(self):
+        from delft.sequenceLabelling.data_loader import _effective_num_workers
+
+        # 100 / 10 = 10 batches, half = 5; requested 11 -> capped to 5
+        assert _effective_num_workers(11, dataset_size=100, batch_size=10) == 5
+
+    def test_returns_zero_for_tiny_dataset(self):
+        from delft.sequenceLabelling.data_loader import _effective_num_workers
+
+        # 9 batches, half = 4; but with 1 batch, half = 0 -> 0 workers
+        assert _effective_num_workers(11, dataset_size=10, batch_size=20) == 0
+
+    def test_does_not_exceed_requested(self):
+        from delft.sequenceLabelling.data_loader import _effective_num_workers
+
+        # plenty of batches but only 2 requested -> stay at 2
+        assert _effective_num_workers(2, dataset_size=10000, batch_size=16) == 2
+
+    def test_handles_zero_dataset_size(self):
+        from delft.sequenceLabelling.data_loader import _effective_num_workers
+
+        assert _effective_num_workers(8, dataset_size=0, batch_size=16) == 0
 
 
 def _to_dense(a: np.array):


### PR DESCRIPTION
Preliminary test on the date model. 


- with embeddings: 
```
                  precision    recall  f1-score   support

           <day>     0.9362    0.9362    0.9362        47
         <month>     0.9508    0.9667    0.9587        60
          <year>     0.9841    0.9688    0.9764        64

all (micro avg.)     0.9591    0.9591    0.9591       171
```

- without embeddings: 
```
                  precision    recall  f1-score   support

           <day>     0.9388    0.9787    0.9583        47
         <month>     1.0000    0.9333    0.9655        60
          <year>     0.9403    0.9844    0.9618        64

all (micro avg.)     0.9593    0.9649    0.9621       171
```


We need to average 5 runs, though, but the results are comparable which convinced me that I could create this PR. 