### PR TITLE
fix: skip padded characters where the Keras encoder masked them

### DIFF
--- a/delft/sequenceLabelling/models.py
+++ b/delft/sequenceLabelling/models.py
@@ -37,13 +37,24 @@ class CharacterEncoder(nn.Module):
         char_vocab_size: Size of character vocabulary
         char_embedding_size: Dimension of character embeddings
         hidden_size: Size of LSTM hidden state
+        mask_zero: Skip padded character positions, as the Keras
+            implementations did where their embedding set mask_zero=True. The
+            LSTM then returns its state at the last real character rather than
+            after running on through the padding.
     """
 
-    def __init__(self, char_vocab_size: int, char_embedding_size: int, hidden_size: int):
+    def __init__(
+        self,
+        char_vocab_size: int,
+        char_embedding_size: int,
+        hidden_size: int,
+        mask_zero: bool = False,
+    ):
         super().__init__()
         self.char_embeddings = nn.Embedding(char_vocab_size, char_embedding_size, padding_idx=0)
         self.bilstm = nn.LSTM(char_embedding_size, hidden_size, batch_first=True, bidirectional=True)
         self.output_size = hidden_size * 2
+        self.mask_zero = mask_zero
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -63,16 +74,35 @@ class CharacterEncoder(nn.Module):
         # Embed characters
         char_emb = self.char_embeddings(x)  # [batch*seq, max_char, emb_size]
 
-        # Encode with BiLSTM
-        _, (hidden, _) = self.bilstm(char_emb)
+        if not self.mask_zero:
+            # Encode with BiLSTM
+            _, (hidden, _) = self.bilstm(char_emb)
 
-        # Concatenate forward and backward hidden states
-        hidden = torch.cat([hidden[0], hidden[1]], dim=-1)  # [batch*seq, hidden*2]
+            # Concatenate forward and backward hidden states
+            hidden = torch.cat([hidden[0], hidden[1]], dim=-1)  # [batch*seq, hidden*2]
 
-        # Reshape back
-        output = hidden.view(batch_size, seq_len, -1)
+            # Reshape back
+            output = hidden.view(batch_size, seq_len, -1)
 
-        return output
+            return output
+
+        # Skip the padding, so that a token encodes the same whatever window
+        # it sits in
+        lengths = (x != 0).sum(dim=1)
+        packed = nn.utils.rnn.pack_padded_sequence(
+            # a length of zero is not packable; those rows are zeroed below
+            char_emb,
+            lengths.clamp(min=1).cpu(),
+            batch_first=True,
+            enforce_sorted=False,
+        )
+        _, (hidden, _) = self.bilstm(packed)
+        hidden = torch.cat([hidden[0], hidden[1]], dim=-1)
+        # a token that is entirely padding is masked out completely, leaving
+        # the initial state rather than whatever a single step produced
+        hidden = hidden * (lengths > 0).unsqueeze(-1).to(hidden.dtype)
+
+        return hidden.view(batch_size, seq_len, -1)
 
 
 class CharacterCNNEncoder(nn.Module):
@@ -209,6 +239,7 @@ class BidLSTM(BaseSequenceLabeler):
             config.char_vocab_size,
             config.char_embedding_size,
             config.num_char_lstm_units,
+            mask_zero=True,
         )
 
         # Input size: word embeddings + character encodings
@@ -291,6 +322,7 @@ class BidLSTM_CRF(BaseSequenceLabeler):
             config.char_vocab_size,
             config.char_embedding_size,
             config.num_char_lstm_units,
+            mask_zero=True,
         )
 
         # Input size
@@ -627,6 +659,7 @@ class BidGRU_CRF(BaseSequenceLabeler):
             config.char_vocab_size,
             config.char_embedding_size,
             config.num_char_lstm_units,
+            mask_zero=True,
         )
 
         # Input size
@@ -712,6 +745,7 @@ class BidLSTM_CRF_FEATURES(BaseSequenceLabeler):
             config.char_vocab_size,
             config.char_embedding_size,
             config.num_char_lstm_units,
+            mask_zero=True,
         )
 
         # Features embedding
@@ -810,6 +844,8 @@ class BidLSTM_ChainCRF_FEATURES(BidLSTM_CRF_FEATURES):
 
     def __init__(self, config: ModelConfig, ntags: int = None):
         super().__init__(config, ntags)
+        # its Keras counterpart set mask_zero=False, unlike BidLSTM_CRF_FEATURES
+        self.char_encoder.mask_zero = False
         # Replace CRF with ChainCRF
         self.crf = ChainCRF(ntags)
         # Add extra dense layer before CRF (matching Keras architecture)
@@ -884,6 +920,7 @@ class BidLSTM_CRF_CASING(BaseSequenceLabeler):
             config.char_vocab_size,
             config.char_embedding_size,
             config.num_char_lstm_units,
+            mask_zero=True,
         )
 
         # Casing embedding

--- a/tests/sequence_labelling/models_test.py
+++ b/tests/sequence_labelling/models_test.py
@@ -1,0 +1,98 @@
+import pytest
+import torch
+
+from delft.sequenceLabelling.config import ModelConfig
+from delft.sequenceLabelling.models import MODEL_REGISTRY, CharacterEncoder
+
+CHAR_VOCAB_SIZE = 10
+CHAR_EMBEDDING_SIZE = 4
+HIDDEN_SIZE = 3
+
+# What the Keras implementations set on the character embedding, per architecture
+# (delft 0.4.3, delft/sequenceLabelling/models.py). The architectures using the
+# CNN character encoder are absent: they have no character LSTM to mask.
+CHARACTER_MASK_ZERO_BY_ARCHITECTURE = {
+    "BidLSTM": True,
+    "BidLSTM_CRF": True,
+    "BidGRU_CRF": True,
+    "BidLSTM_CRF_CASING": True,
+    "BidLSTM_CRF_FEATURES": True,
+    "BidLSTM_ChainCRF": False,
+    "BidLSTM_ChainCRF_FEATURES": False,
+}
+
+
+def get_model_config(architecture: str) -> ModelConfig:
+    config = ModelConfig(
+        architecture=architecture,
+        word_embedding_size=8,
+        char_emb_size=CHAR_EMBEDDING_SIZE,
+        char_lstm_units=HIDDEN_SIZE,
+        word_lstm_units=6,
+        dropout=0.0,
+        recurrent_dropout=0.0,
+    )
+    config.char_vocab_size = CHAR_VOCAB_SIZE
+    config.case_vocab_size = 8
+    return config
+
+
+class TestCharacterEncoder:
+    def test_should_not_mask_padding_by_default(self):
+        encoder = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE)
+        assert encoder.mask_zero is False
+
+    @pytest.mark.parametrize("mask_zero", [False, True])
+    def test_should_return_the_expected_shape(self, mask_zero: bool):
+        encoder = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE, mask_zero=mask_zero)
+        encoder.eval()
+        with torch.no_grad():
+            output = encoder(torch.tensor([[[1, 2, 0], [3, 0, 0]]]))
+        assert output.shape == (1, 2, HIDDEN_SIZE * 2)
+
+    def test_should_encode_a_token_the_same_whatever_the_character_window(self):
+        # the same token, padded to a wider character window
+        encoder = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE, mask_zero=True)
+        encoder.eval()
+        with torch.no_grad():
+            narrow = encoder(torch.tensor([[[1, 2, 0]]]))
+            wide = encoder(torch.tensor([[[1, 2, 0, 0, 0, 0]]]))
+        assert torch.allclose(narrow, wide, atol=1e-6)
+
+    def test_should_encode_each_token_independently_of_the_others(self):
+        encoder = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE, mask_zero=True)
+        encoder.eval()
+        tokens = torch.tensor([[[5, 6, 7, 8], [2, 0, 0, 0], [3, 4, 0, 0]]])
+        with torch.no_grad():
+            together = encoder(tokens)
+            separately = torch.cat(
+                [encoder(tokens[:, index : index + 1, :]) for index in range(tokens.shape[1])], dim=1
+            )
+        assert torch.allclose(together, separately, atol=1e-6)
+
+    def test_should_encode_a_token_without_padding_the_same_as_without_masking(self):
+        masked = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE, mask_zero=True)
+        unmasked = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE)
+        unmasked.load_state_dict(masked.state_dict())
+        masked.eval()
+        unmasked.eval()
+        full_window = torch.tensor([[[1, 2, 3]]])
+        with torch.no_grad():
+            assert torch.allclose(masked(full_window), unmasked(full_window), atol=1e-6)
+
+    def test_should_return_zeros_for_a_token_that_is_entirely_padding(self):
+        # as Keras did, leaving the initial state rather than encoding the padding
+        encoder = CharacterEncoder(CHAR_VOCAB_SIZE, CHAR_EMBEDDING_SIZE, HIDDEN_SIZE, mask_zero=True)
+        encoder.eval()
+        with torch.no_grad():
+            output = encoder(torch.tensor([[[0, 0, 0]]]))
+        assert torch.equal(output, torch.zeros_like(output))
+
+
+class TestCharacterMaskZeroByArchitecture:
+    @pytest.mark.parametrize("architecture,expected_mask_zero", sorted(CHARACTER_MASK_ZERO_BY_ARCHITECTURE.items()))
+    def test_should_mask_padded_characters_where_the_keras_embedding_did(
+        self, architecture: str, expected_mask_zero: bool
+    ):
+        model = MODEL_REGISTRY[architecture](get_model_config(architecture), ntags=5)
+        assert model.char_encoder.mask_zero is expected_mask_zero


### PR DESCRIPTION
The Keras implementations set mask_zero per architecture on the character embedding: True for BidLSTM, BidLSTM_CRF, BidGRU_CRF, BidLSTM_CRF_CASING and BidLSTM_CRF_FEATURES, False for BidLSTM_ChainCRF, BidLSTM_CNN, BidLSTM_CNN_CRF and BidLSTM_ChainCRF_FEATURES. Collapsing those call sites onto one shared CharacterEncoder implemented the unmasked behaviour for all of them, so the ones that masked lost it.

With masking, a bidirectional LSTM returning only its final state returns the state at the last real character. Without it the LSTM runs on through the padding -- for a three-character token in a thirty-character window, twenty-seven further steps -- so what reaches the rest of the model is largely a function of the padding embedding, and the same token encodes differently depending on the window it sits in.

CharacterEncoder now takes mask_zero, defaulting to False so that nothing not listed above changes, and the call sites pass what their Keras counterparts set. BidLSTM_ChainCRF_FEATURES resets it, inheriting from BidLSTM_CRF_FEATURES where the two differed.

Measured on GROBID's 0.8.2 header-BidLSTM_CRF weights, over 20 documents: 0.5219 micro F1 before, 0.7583 after, against 0.7724 from the TensorFlow implementation. The rest of that gap is the same mask at the token level, which is separate.

Checked against Keras itself: with the 0.4.3 character pathway rebuilt in Keras and its weights copied across, the masked encoder matches to 2.8e-9 where the unmasked one differs in the third decimal.

The new tests cover CharacterEncoder, which had none, and lock in the per architecture flag against the table above.