### PR TITLE
fix: mask padded tokens in BidLSTM_CRF, so batching cannot change a result

### DIFF
--- a/delft/sequenceLabelling/models.py
+++ b/delft/sequenceLabelling/models.py
@@ -105,6 +105,29 @@ class CharacterEncoder(nn.Module):
         return hidden.view(batch_size, seq_len, -1)
 
 
+def get_token_mask(char_input: torch.Tensor) -> torch.Tensor:
+    """Marks the token positions that are not padding.
+
+    Keras derived this from the character embedding's own mask, reduced over the
+    character axis, so a token counts as padding when every one of its
+    characters does. Taking it from char_input rather than from the length input
+    reproduces that and works whether or not a length was supplied.
+    """
+    mask = (char_input != 0).any(dim=-1)
+    # the CRF requires the first position of every sequence to be unmasked
+    mask[:, 0] = True
+    return mask
+
+
+def run_masked_lstm(lstm: nn.LSTM, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Runs a sequence LSTM over the real positions only."""
+    lengths = mask.sum(dim=1)
+    packed = nn.utils.rnn.pack_padded_sequence(x, lengths.clamp(min=1).cpu(), batch_first=True, enforce_sorted=False)
+    packed_output, _ = lstm(packed)
+    output, _ = nn.utils.rnn.pad_packed_sequence(packed_output, batch_first=True, total_length=x.shape[1])
+    return output
+
+
 class CharacterCNNEncoder(nn.Module):
     """
     Character-level encoder using CNN.
@@ -353,16 +376,11 @@ class BidLSTM_CRF(BaseSequenceLabeler):
         word_emb = inputs["word_input"]
         char_input = inputs["char_input"]
 
-        # Get sequence lengths for masking
-        lengths = inputs.get("length", None)
-        if lengths is not None:
-            # Create mask from lengths
-            batch_size, seq_len = word_emb.shape[:2]
-            mask = torch.arange(seq_len, device=word_emb.device).expand(batch_size, seq_len)
-            mask = mask < lengths.squeeze(-1).unsqueeze(-1)
-            mask = mask.float()
-        else:
-            mask = None
+        # The Keras mask propagated from the character embedding through the
+        # Concatenate into this LSTM, so padded token positions took no part in
+        # the sequence over them and a document's output did not depend on the
+        # batch it was in.
+        mask = get_token_mask(char_input)
 
         # Encode characters
         char_encoded = self.char_encoder(char_input)
@@ -371,8 +389,8 @@ class BidLSTM_CRF(BaseSequenceLabeler):
         x = torch.cat([word_emb, char_encoded], dim=-1)
         x = self.dropout(x)
 
-        # BiLSTM
-        lstm_out, _ = self.bilstm(x)
+        # BiLSTM over the real positions only
+        lstm_out = run_masked_lstm(self.bilstm, x, mask)
         lstm_out = self.dropout(lstm_out)
 
         # Dense
@@ -391,20 +409,13 @@ class BidLSTM_CRF(BaseSequenceLabeler):
     def decode(self, inputs: Dict[str, torch.Tensor]) -> List[List[int]]:
         """Decode using Viterbi."""
         with torch.no_grad():
+            mask = get_token_mask(inputs["char_input"])
             outputs = self.forward(inputs)
-
-            # Get mask
-            lengths = inputs.get("length", None)
-            if lengths is not None:
-                batch_size, seq_len = outputs["logits"].shape[:2]
-                mask = torch.arange(seq_len, device=outputs["logits"].device).expand(batch_size, seq_len)
-                mask = mask < lengths.squeeze(-1).unsqueeze(-1)
-                mask = mask.float()
-            else:
-                mask = None
-
             predictions = self.crf.decode(outputs["logits"], mask=mask)
-        return predictions
+        # a masked decode returns only the real positions; callers expect one
+        # tag per position, so the padding is filled back in
+        sequence_length = outputs["logits"].shape[1]
+        return [tags + [0] * (sequence_length - len(tags)) for tags in predictions]
 
 
 class BidLSTM_ChainCRF(BaseSequenceLabeler):

--- a/tests/sequence_labelling/models_test.py
+++ b/tests/sequence_labelling/models_test.py
@@ -1,12 +1,21 @@
 import pytest
 import torch
+import torch.nn as nn
 
 from delft.sequenceLabelling.config import ModelConfig
-from delft.sequenceLabelling.models import MODEL_REGISTRY, CharacterEncoder
+from delft.sequenceLabelling.models import (
+    MODEL_REGISTRY,
+    BidLSTM_CRF,
+    CharacterEncoder,
+    get_token_mask,
+    run_masked_lstm,
+)
 
 CHAR_VOCAB_SIZE = 10
 CHAR_EMBEDDING_SIZE = 4
 HIDDEN_SIZE = 3
+WORD_EMBEDDING_SIZE = 8
+NTAGS = 5
 
 # What the Keras implementations set on the character embedding, per architecture
 # (delft 0.4.3, delft/sequenceLabelling/models.py). The architectures using the
@@ -21,11 +30,22 @@ CHARACTER_MASK_ZERO_BY_ARCHITECTURE = {
     "BidLSTM_ChainCRF_FEATURES": False,
 }
 
+# two documents, the first a token shorter than the second, so that batching
+# them together pads the first
+CHAR_INPUT = torch.tensor(
+    [
+        [[1, 2], [3, 1], [0, 0]],
+        [[4, 5], [6, 7], [8, 9]],
+    ]
+)
+
+SHORTER_DOCUMENT_LENGTH = 2
+
 
 def get_model_config(architecture: str) -> ModelConfig:
     config = ModelConfig(
         architecture=architecture,
-        word_embedding_size=8,
+        word_embedding_size=WORD_EMBEDDING_SIZE,
         char_emb_size=CHAR_EMBEDDING_SIZE,
         char_lstm_units=HIDDEN_SIZE,
         word_lstm_units=6,
@@ -35,6 +55,22 @@ def get_model_config(architecture: str) -> ModelConfig:
     config.char_vocab_size = CHAR_VOCAB_SIZE
     config.case_vocab_size = 8
     return config
+
+
+@pytest.fixture(name="model")
+def _model():
+    # an untrained model may decode the same tags either way by chance; this
+    # seed is one where the unmasked implementation decodes different ones
+    torch.manual_seed(4)
+    model = BidLSTM_CRF(get_model_config("BidLSTM_CRF"), NTAGS)
+    model.eval()
+    return model
+
+
+@pytest.fixture(name="word_input")
+def _word_input():
+    torch.manual_seed(1)
+    return torch.randn(CHAR_INPUT.shape[0], CHAR_INPUT.shape[1], WORD_EMBEDDING_SIZE)
 
 
 class TestCharacterEncoder:
@@ -94,5 +130,90 @@ class TestCharacterMaskZeroByArchitecture:
     def test_should_mask_padded_characters_where_the_keras_embedding_did(
         self, architecture: str, expected_mask_zero: bool
     ):
-        model = MODEL_REGISTRY[architecture](get_model_config(architecture), ntags=5)
+        model = MODEL_REGISTRY[architecture](get_model_config(architecture), ntags=NTAGS)
         assert model.char_encoder.mask_zero is expected_mask_zero
+
+
+class TestGetTokenMask:
+    def test_should_mark_a_token_with_at_least_one_character_as_real(self):
+        mask = get_token_mask(torch.tensor([[[1, 0], [0, 2]]]))
+        assert mask.tolist() == [[True, True]]
+
+    def test_should_mark_a_token_that_is_entirely_padding(self):
+        mask = get_token_mask(torch.tensor([[[1, 2], [0, 0]]]))
+        assert mask.tolist() == [[True, False]]
+
+    def test_should_keep_the_first_position_unmasked_where_the_crf_requires_it(self):
+        mask = get_token_mask(torch.zeros(1, 2, 2, dtype=torch.long))
+        assert mask.tolist() == [[True, False]]
+
+
+class TestRunMaskedLstm:
+    def test_should_return_the_full_padded_length(self):
+        lstm = nn.LSTM(4, 3, batch_first=True, bidirectional=True)
+        x = torch.randn(2, 5, 4)
+        mask = torch.tensor([[True] * 3 + [False] * 2, [True] * 5])
+        assert run_masked_lstm(lstm, x, mask).shape == (2, 5, 6)
+
+    def test_should_not_let_padding_reach_the_real_positions(self):
+        torch.manual_seed(42)
+        lstm = nn.LSTM(4, 3, batch_first=True, bidirectional=True)
+        x = torch.randn(1, 5, 4)
+        padded = run_masked_lstm(lstm, x, torch.tensor([[True] * 3 + [False] * 2]))
+        unpadded = run_masked_lstm(lstm, x[:, :3], torch.tensor([[True] * 3]))
+        # without the mask the backward direction would start in the padding and
+        # run back through it, reaching every position
+        assert torch.allclose(padded[:, :3], unpadded, atol=1e-6)
+
+
+class TestBidLSTMCRF:
+    def test_should_give_the_same_logits_whatever_the_document_is_batched_with(self, model, word_input):
+        with torch.no_grad():
+            batched = model({"word_input": word_input, "char_input": CHAR_INPUT})
+            on_its_own = model(
+                {
+                    "word_input": word_input[:1, :SHORTER_DOCUMENT_LENGTH],
+                    "char_input": CHAR_INPUT[:1, :SHORTER_DOCUMENT_LENGTH],
+                }
+            )
+        assert torch.allclose(
+            batched["logits"][:1, :SHORTER_DOCUMENT_LENGTH],
+            on_its_own["logits"],
+            atol=1e-6,
+        )
+
+    def test_should_give_the_same_tags_whatever_the_document_is_batched_with(self, model, word_input):
+        batched = model.decode({"word_input": word_input, "char_input": CHAR_INPUT})
+        on_its_own = model.decode(
+            {
+                "word_input": word_input[:1, :SHORTER_DOCUMENT_LENGTH],
+                "char_input": CHAR_INPUT[:1, :SHORTER_DOCUMENT_LENGTH],
+            }
+        )
+        assert batched[0][:SHORTER_DOCUMENT_LENGTH] == on_its_own[0]
+
+    def test_should_give_the_same_loss_whatever_the_document_is_batched_with(self, model, word_input):
+        labels = torch.tensor([[1, 2, 0], [3, 1, 2]])
+        with torch.no_grad():
+            batched = model(
+                {"word_input": word_input[:1], "char_input": CHAR_INPUT[:1]},
+                labels=labels[:1],
+            )
+            on_its_own = model(
+                {
+                    "word_input": word_input[:1, :SHORTER_DOCUMENT_LENGTH],
+                    "char_input": CHAR_INPUT[:1, :SHORTER_DOCUMENT_LENGTH],
+                },
+                labels=labels[:1, :SHORTER_DOCUMENT_LENGTH],
+            )
+        assert torch.allclose(batched["loss"], on_its_own["loss"], atol=1e-6)
+
+    def test_should_decode_one_tag_per_position(self, model, word_input):
+        # a masked decode returns only the real positions, where callers expect
+        # a rectangular result
+        predictions = model.decode({"word_input": word_input, "char_input": CHAR_INPUT})
+        assert [len(tags) for tags in predictions] == [CHAR_INPUT.shape[1]] * CHAR_INPUT.shape[0]
+
+    def test_should_decode_padded_positions_as_the_padding_tag(self, model, word_input):
+        predictions = model.decode({"word_input": word_input, "char_input": CHAR_INPUT})
+        assert predictions[0][SHORTER_DOCUMENT_LENGTH:] == [0]


### PR DESCRIPTION
The word BiLSTM ran over the full padded batch. Under Keras the mask from the character embedding's mask_zero=True propagated through the Concatenate into this LSTM, so padded token positions took no part in the sequence over them and a document's output did not depend on the batch it was in.

Without the mask those positions are processed as real, and the effect is not confined to them: the backward direction starts in the padding and runs back through it before reaching any real token, so the padding reaches every position. Evaluating or tagging the same document therefore gives different results at different batch sizes, silently, for any BidLSTM_CRF model however it was trained.

The word LSTM is now packed by token length and the same mask is passed to the CRF, as the Keras layer received it. The mask comes from char_input rather than from the length input, so it does not depend on a length being supplied.

Measured on GROBID's 0.8.2 header-BidLSTM_CRF weights over 20 documents, with the companion character-level masking change in place: 0.7583 micro F1 at batch size 9 and 0.7724425887 at batch size 1, the latter being what the TensorFlow implementation scores to every digit it reports.

Note that decode previously returned a rectangular result because it usually had no mask to pass; it now fills the padding back in to keep that.

No test covered BidLSTM_CRF, which is why this survived release, so tests/sequence_labelling/models_test.py is added: it covers the two helpers and asserts that logits, decoded tags and CRF loss are all unaffected by what a document is batched with. Four of its cases fail without this change.

The same reasoning applies to the other architectures whose Keras counterparts set mask_zero=True -- BidLSTM, BidGRU_CRF, BidLSTM_CRF_CASING and BidLSTM_CRF_FEATURES -- which is why the helpers are shared rather than inlined. Only BidLSTM_CRF is changed here, being the one with a published model to verify against.