### PR TITLE
fix: build ChainCRF parameters when the tag count is known

### DIFF
--- a/delft/utilities/crf_pytorch.py
+++ b/delft/utilities/crf_pytorch.py
@@ -243,6 +243,13 @@ class ChainCRF(nn.Module):
         self.b_start = None  # Start boundary energy
         self.b_end = None  # End boundary energy
 
+        # Build now when the tag count is already known, so that the parameters
+        # are registered before an optimizer is constructed over
+        # model.parameters() and are present in state_dict(). Building them
+        # lazily in forward() leaves them out of both.
+        if num_tags is not None:
+            self.build(num_tags)
+
     def build(self, num_tags: int, device=None, dtype=None):
         """Initialize layer weights."""
         self._num_tags = num_tags

--- a/tests/utilities/test_crf_pytorch.py
+++ b/tests/utilities/test_crf_pytorch.py
@@ -1,0 +1,68 @@
+"""
+Tests for the CRF layers in delft/utilities/crf_pytorch.py
+"""
+
+import logging
+
+import torch
+from torch.optim import Adam
+
+from delft.utilities.crf_pytorch import ChainCRF
+
+LOGGER = logging.getLogger(__name__)
+
+NUM_TAGS = 5
+BATCH_SIZE = 2
+SEQUENCE_LENGTH = 4
+
+PARAMETER_NAMES = {"U", "b_start", "b_end"}
+
+
+def _emissions_and_tags():
+    torch.manual_seed(42)
+    emissions = torch.randn(BATCH_SIZE, SEQUENCE_LENGTH, NUM_TAGS, requires_grad=True)
+    tags = torch.randint(0, NUM_TAGS, (BATCH_SIZE, SEQUENCE_LENGTH))
+    return emissions, tags
+
+
+class TestChainCRF:
+    """Tests for the ChainCRF layer."""
+
+    def test_parameters_registered_when_num_tags_is_known(self):
+        chain_crf = ChainCRF(NUM_TAGS)
+        assert set(chain_crf.state_dict().keys()) == PARAMETER_NAMES
+        assert chain_crf.U.shape == (NUM_TAGS, NUM_TAGS)
+        assert chain_crf.b_start.shape == (NUM_TAGS,)
+        assert chain_crf.b_end.shape == (NUM_TAGS,)
+
+    def test_parameters_built_lazily_without_num_tags(self):
+        chain_crf = ChainCRF()
+        assert not chain_crf.state_dict()
+        emissions, tags = _emissions_and_tags()
+        chain_crf(emissions, tags)
+        assert set(chain_crf.state_dict().keys()) == PARAMETER_NAMES
+
+    def test_optimizer_created_before_first_forward_updates_transitions(self):
+        chain_crf = ChainCRF(NUM_TAGS)
+        optimizer = Adam(chain_crf.parameters(), lr=0.1)
+        emissions, tags = _emissions_and_tags()
+        transitions_before = chain_crf.U.detach().clone()
+        for _ in range(5):
+            optimizer.zero_grad()
+            chain_crf(emissions, tags).backward()
+            optimizer.step()
+        assert not torch.equal(transitions_before, chain_crf.U.detach())
+
+    def test_state_dict_round_trip(self):
+        chain_crf = ChainCRF(NUM_TAGS)
+        emissions, tags = _emissions_and_tags()
+        chain_crf(emissions, tags)
+        loaded_chain_crf = ChainCRF(NUM_TAGS)
+        loaded_chain_crf.load_state_dict(chain_crf.state_dict())
+        assert torch.equal(loaded_chain_crf.U.detach(), chain_crf.U.detach())
+
+    def test_decode_returns_a_tag_per_token(self):
+        chain_crf = ChainCRF(NUM_TAGS)
+        emissions, _ = _emissions_and_tags()
+        decoded = chain_crf.decode(emissions)
+        assert torch.as_tensor(decoded).shape == (BATCH_SIZE, SEQUENCE_LENGTH)


### PR DESCRIPTION
ChainCRF created U, b_start and b_end on its first forward pass. Three consequences, none of which surface as an error at the point of cause:

- Trainer.compile_model constructs the optimizer over model.parameters() before the first batch, and Adam fixes its param groups at construction, so the transition matrix received gradients but never an update. Training proceeded normally and the CRF simply stayed at its initial values.
- A freshly constructed model had no crf.* entries in its state_dict, so loading a saved model raised on unexpected keys. Sequence.load is affected, since it constructs the model through get_model before load_state_dict.
- decode() dereferences b_start and b_end without going through the build check that forward() has, so it raised a TypeError on a layer that had not had a forward pass yet.

All four ChainCRF architectures are affected: BidLSTM_ChainCRF, BidLSTM_ChainCRF_FEATURES, BERT_ChainCRF and BERT_ChainCRF_FEATURES.

Building in __init__ when num_tags is given fixes all three. The lazy path is kept for ChainCRF() without a tag count, which is the only case it was needed for.

The added tests fail without this change (three by assertion, one by the decode TypeError) and the existing suite is unaffected: 135 passed before and after.